### PR TITLE
Reduce cost of Bandages, Burn and Trauma Kits

### DIFF
--- a/code/game/objects/items/stacks/civ_recipes.dm
+++ b/code/game/objects/items/stacks/civ_recipes.dm
@@ -461,13 +461,13 @@
 /material/cloth/generate_recipes_civs(var/list/current_res = list(0,0,0))
 	..()
 	if (current_res[3] >= 19)
-		recipes += list(new/datum/stack_recipe("bandages", /obj/item/stack/medical/bruise_pack/bint, 2, _time = 75, _one_per_turf = FALSE, _on_floor = TRUE))
+		recipes += list(new/datum/stack_recipe("bandages", /obj/item/stack/medical/bruise_pack/bint, 1, _time = 75, _one_per_turf = FALSE, _on_floor = TRUE))
 		recipes += list(new/datum/stack_recipe("foldable canopy", /obj/item/weapon/tent, 4, _time = 75, _one_per_turf = FALSE, _on_floor = TRUE))
 
 	if (current_res[3] >= 56)
-		recipes += list(new/datum/stack_recipe("trauma kit", /obj/item/stack/medical/advanced/bruise_pack, 5, _time = 105, _one_per_turf = FALSE, _on_floor = TRUE))
+		recipes += list(new/datum/stack_recipe("trauma kit", /obj/item/stack/medical/advanced/bruise_pack, 2, _time = 105, _one_per_turf = FALSE, _on_floor = TRUE))
 	if (current_res[3] >= 43)
-		recipes += list(new/datum/stack_recipe("burn kit", /obj/item/stack/medical/advanced/ointment, 4, _time = 90, _one_per_turf = FALSE, _on_floor = TRUE))
+		recipes += list(new/datum/stack_recipe("burn kit", /obj/item/stack/medical/advanced/ointment, 1, _time = 90, _one_per_turf = FALSE, _on_floor = TRUE))
 	recipes += list(new/datum/stack_recipe("custom flag maker", /obj/item/flagmaker, 4, _time = 100, _one_per_turf = FALSE, _on_floor = TRUE))
 
 	if ((current_res[3] >= 18) && (current_res[3] < 38))


### PR DESCRIPTION
This should reduce the cost of the afforementioned items. It'll also be my first code contribution to a Space Station 13 server.
The reduction is as follows:
Bandages: From 2 cloth to 1 cloth.
Burn Kits: From 4 cloth to 1 cloth.
Trauma Kits: From 5 cloth to 2 cloth.
This is to hopefully allow for  easier access to advanced medicine without having to harvest great swaths of cotton to carry the cost.
Values suggested by Admiral Taislin and Sgt. Shinobi on the Civ13 Discord.

Did I do this right?